### PR TITLE
Removing transitive dependency to jQuery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
             <version>3.1.1-1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.webjars</groupId>
+                    <artifactId>jquery</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The whole point of angular-ui-bootstrap is to use AngularJS to power the JS components of Bootstrap, that are normally powered by jQuery. So, jQuery should not be fetched as a transitive dependency of the Bootstrap webjar.

BEFORE:
loophole:angular-ui-bootstrap deadlock$ mvn dependency:tree
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO]  
[INFO] ------------------------------------------------------------------------
[INFO] Building Angular Ui Bootstrap 0.11.0-3-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ angular-ui-bootstrap ---
[INFO] org.webjars:angular-ui-bootstrap:jar:0.11.0-3-SNAPSHOT
[INFO] +- org.webjars:angularjs:jar:1.2.16-2:compile
[INFO] - org.webjars:bootstrap:jar:3.1.1-1:compile
[INFO]    - org.webjars:jquery:jar:1.9.0:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.760 s
[INFO] Finished at: 2014-09-17T00:35:49+03:00
[INFO] Final Memory: 10M/81M
[INFO] ------------------------------------------------------------------------
loophole:angular-ui-bootstrap deadlock$ 

AFTER:
loophole:angular-ui-bootstrap deadlock$ mvn dependency:tree
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO]  
[INFO] ------------------------------------------------------------------------
[INFO] Building Angular Ui Bootstrap 0.11.0-3-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ angular-ui-bootstrap ---
[INFO] org.webjars:angular-ui-bootstrap:jar:0.11.0-3-SNAPSHOT
[INFO] +- org.webjars:angularjs:jar:1.2.16-2:compile
[INFO] - org.webjars:bootstrap:jar:3.1.1-1:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.545 s
[INFO] Finished at: 2014-09-17T00:34:58+03:00
[INFO] Final Memory: 10M/81M
[INFO] ------------------------------------------------------------------------
loophole:angular-ui-bootstrap deadlock$ 
